### PR TITLE
Pre-populate states

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -69,7 +69,7 @@ let createHistory = (source, options) => {
 let createMemorySource = (initialPathname = "/") => {
   let index = 0;
   let stack = [{ pathname: initialPathname, search: "" }];
-  let states = [];
+  let states = [{ key: Date.now() + "" }];
 
   return {
     get location() {


### PR DESCRIPTION
This is to ensure it stays in sync with `stack` as `index` is used for both.  Otherwise, they're always off-by-one.

Closes #180.